### PR TITLE
fix: be quiet when the $quiet flag is set

### DIFF
--- a/poweredge-fand.pl
+++ b/poweredge-fand.pl
@@ -129,7 +129,7 @@ sub set_fans_servo {
   print "weighted_temp = $weighted_temp ; ambient_temp $ambient_temp\n" if $print_stats;
 
   if ((!defined $current_mode) or ($current_mode ne "set")) {
-    print "--> disable dynamic fan control\n";
+    print "--> disable dynamic fan control\n" if !$quiet;
     system("ipmitool raw 0x30 0x30 0x01 0x00") == 0 or return 0;
     # if this fails, want to return telling caller not to think weve
     # made a change

--- a/poweredge-fand.pl
+++ b/poweredge-fand.pl
@@ -129,7 +129,7 @@ sub set_fans_servo {
   print "weighted_temp = $weighted_temp ; ambient_temp $ambient_temp\n" if $print_stats;
 
   if ((!defined $current_mode) or ($current_mode ne "set")) {
-    print "--> disable dynamic fan control\n" if !$quiet;
+    print "--> disable dynamic fan control\n" if !($quiet and (defined $current_mode) and ($current_mode eq "reset"));
     system("ipmitool raw 0x30 0x30 0x01 0x00") == 0 or return 0;
     # if this fails, want to return telling caller not to think weve
     # made a change


### PR DESCRIPTION
My syslogs are basically flooded with that "--> disable dynamic fan control" message. Despite passing the -q flag in the systemd unit file, the logs from this program (and more specifically, that single message) make up at least 60% of my log entries.

This fixes that issue by only printing the message when quiet is false.


~~Ideally, the message would still be printed when the status *changes* (as in, it goes from enabled to disabled), but idk if I can do that.~~